### PR TITLE
Fixed ts-toolbelt version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,9 +3164,9 @@
       }
     },
     "ts-toolbelt": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.12.2.tgz",
-      "integrity": "sha512-Z9VWXJ32UpLrjw5OqieJ944heNN5gkVm69VLvVf9GgrdxoxPiM4ughyYFip6pIDqRnrVuiegMTD48zxnOW5j/Q=="
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-8.0.4.tgz",
+      "integrity": "sha512-ug9shEyrhblB0mmVtFO6ZMdsKhFzjSmSVJJ24DRbTy3s4zrraEvQnE4sYvcVVszoSfQGHqOnWQMlse+b4U6yGA=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
     "test": "ava",
     "rollup": "rollup -c build/rollup.js",
-    "build": "npm run lint && npm run lint && npm run test && npm run rollup"
+    "build": "npm run lint && npm run test && npm run rollup"
   },
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/mesqueeb/merge-anything#readme",
   "dependencies": {
     "is-what": "^3.10.0",
-    "ts-toolbelt": "6.12.2"
+    "ts-toolbelt": ">=6.12.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.34.0",


### PR DESCRIPTION
Changed ts-toolbelt version in order to prevent version conflict when typescript project depends on both merge-anything and ts-toolbelt. Also removed extra linting step in build script.