### PR TITLE
limit version of ts-toolbelt to 8.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/mesqueeb/merge-anything#readme",
   "dependencies": {
     "is-what": "^3.11.3",
-    "ts-toolbelt": "^8.0.7"
+    "ts-toolbelt": "8.0.x"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.6.1",


### PR DESCRIPTION
ts-toolbelt does not compile with 8.4.0, so we should only depend on 8.0

resolves: #13 

```ts
.yarn/cache/ts-toolbelt-npm-8.4.0-f6995cd030-dbc3ad2626.zip/node_modules/ts-toolbelt/out/index.d.ts:983:46 - error TS1110: Type expected.

983     export type NumberOf<N extends number> = `${N}`;
```

*NOTE*: I did not update the package lock, so that would need to be updated.